### PR TITLE
Add startedAt property to timer, use for decrementing logic

### DIFF
--- a/lib/entities/timer.js
+++ b/lib/entities/timer.js
@@ -36,7 +36,8 @@ const timer = (userId, name, duration, intervalDuration) => {
     duration,
     remainingDuration: duration,
     intervalDuration,
-    isRunning: false
+    isRunning: false,
+    startedAt: null
   }
 
 }

--- a/lib/useCases/timer.js
+++ b/lib/useCases/timer.js
@@ -97,14 +97,14 @@ const startTimer = findTimerById => {
       throw new TypeError(utils.constructErrorMessage('saveTimer', 'function', saveTimer))
     }
 
-    return async id => {
+    return async (id, date) => {
 
       if(typeof id !== 'string'){
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
       }
 
       const timer = await findTimerById(id)
-      const startedTimer = Object.assign({}, timer, {isRunning: true})
+      const startedTimer = Object.assign({}, timer, {isRunning: true, startedAt: date})
       try {
         await saveTimer(startedTimer)
         return startedTimer
@@ -138,7 +138,7 @@ const stopTimer = findTimerById => {
       const stoppedTimer = Object.assign(
         {},
         timer,
-        {isRunning: false}
+        {isRunning: false, startedAt: null}
       )
       try{
         await saveTimer(stoppedTimer)
@@ -162,7 +162,7 @@ const decrementTimer = findTimerById => {
       throw new TypeError(utils.constructErrorMessage("saveTimer", "function", saveTimer))
     }
 
-    return async id => {
+    return async (id, date) => {
 
       if(typeof id !== 'string'){
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
@@ -170,7 +170,7 @@ const decrementTimer = findTimerById => {
 
       const timer = await findTimerById(id)
       const remainingDuration = 
-        timer.remainingDuration - timer.intervalDuration
+        timer.remainingDuration - (date - timer.startedAt)
       let decrementedTimer = Object.assign(
         {},
         timer,
@@ -180,7 +180,7 @@ const decrementTimer = findTimerById => {
         decrementedTimer = Object.assign(
           {},
           decrementedTimer,
-          {isRunning: false}
+          {isRunning: false, remainingDuration: 0}
         )
       }
       try{

--- a/lib/useCases/timer.js
+++ b/lib/useCases/timer.js
@@ -97,14 +97,14 @@ const startTimer = findTimerById => {
       throw new TypeError(utils.constructErrorMessage('saveTimer', 'function', saveTimer))
     }
 
-    return async (id, date) => {
+    return async (id, dateMs) => {
 
       if(typeof id !== 'string'){
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
       }
 
       const timer = await findTimerById(id)
-      const startedTimer = Object.assign({}, timer, {isRunning: true, startedAt: date})
+      const startedTimer = Object.assign({}, timer, {isRunning: true, startedAt: dateMs})
       try {
         await saveTimer(startedTimer)
         return startedTimer
@@ -162,7 +162,7 @@ const decrementTimer = findTimerById => {
       throw new TypeError(utils.constructErrorMessage("saveTimer", "function", saveTimer))
     }
 
-    return async (id, date) => {
+    return async (id, dateMs) => {
 
       if(typeof id !== 'string'){
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
@@ -170,7 +170,7 @@ const decrementTimer = findTimerById => {
 
       const timer = await findTimerById(id)
       const remainingDuration = 
-        timer.remainingDuration - (date - timer.startedAt)
+        timer.remainingDuration - (dateMs - timer.startedAt)
       let decrementedTimer = Object.assign(
         {},
         timer,

--- a/lib/useCases/timer.js
+++ b/lib/useCases/timer.js
@@ -103,6 +103,10 @@ const startTimer = findTimerById => {
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
       }
 
+      if(typeof dateMs !== "number"){
+        throw new TypeError(utils.constructErrorMessage('dateMs', "number", dateMs))
+      }
+
       const timer = await findTimerById(id)
       const startedTimer = Object.assign({}, timer, {isRunning: true, startedAt: dateMs})
       try {
@@ -166,6 +170,10 @@ const decrementTimer = findTimerById => {
 
       if(typeof id !== 'string'){
         throw new TypeError(utils.constructErrorMessage('id', 'string', id))
+      }
+
+      if(typeof dateMs !== "number"){
+        throw new TypeError(utils.constructErrorMessage("dateMs", "number", dateMs))
       }
 
       const timer = await findTimerById(id)

--- a/test/useCases/timer.js
+++ b/test/useCases/timer.js
@@ -339,7 +339,8 @@ describe('start timer use case', () => {
         duration: 1000,
         remainingDuration: 1000,
         intervalDuration: 1000,
-        isRunning: false
+        isRunning: false,
+        startedAt: null
       }
     }
 
@@ -350,7 +351,9 @@ describe('start timer use case', () => {
       saveTimerArg = timer
     }
 
-    const startedTimerPromise = core.startTimerUseCase(findTimerById)(saveTimer)("1")
+    const date = Date.now()
+
+    const startedTimerPromise = core.startTimerUseCase(findTimerById)(saveTimer)("1", date)
 
     it('should call findTimerById', () => {
       findTimerByIdCalled.should.equal(true)
@@ -378,6 +381,10 @@ describe('start timer use case', () => {
 
     it('should have isRunning prop equal true', () => {
       return startedTimerPromise.should.eventually.have.property("isRunning").equal(true)
+    })
+
+    it("should have startedAt time equal to date arg", () => {
+      return startedTimerPromise.should.eventually.have.property("startedAt").equal(date)
     })
 
   })
@@ -440,7 +447,8 @@ describe('stop timer use case', () => {
         name: "timer",
         remainingDuration: 1000,
         intervalDuration: 1000,
-        isRunning: true
+        isRunning: true,
+        startedAt: Date.now()
       }
     }
 
@@ -487,6 +495,10 @@ describe('stop timer use case', () => {
 
     it('should have isRunning equal false', () => {
       return stoppedTimerPromise.should.eventually.have.property('isRunning').equal(false)
+    })
+
+    it('should have startedAt equal to null', () => {
+      return stoppedTimerPromise.should.eventually.have.property("startedAt").equal(null)
     })
 
   })
@@ -539,6 +551,8 @@ describe('decrement timer use case', () => {
   
   describe('happy path', () => {
 
+    const date = Date.now()
+
     let findTimerByIdCalled = false
     let findTimerByIdArg = ""
     const findTimerById = id => {
@@ -550,7 +564,8 @@ describe('decrement timer use case', () => {
         duration: 1000,
         remainingDuration: 1000,
         intervalDuration: 1000,
-        isRunning: true
+        isRunning: true,
+        startedAt: date - 10
       }
     }
 
@@ -561,7 +576,7 @@ describe('decrement timer use case', () => {
       saveTimerArg = timer
     }
 
-    const decrementedTimerPromise = core.decrementTimerUseCase(findTimerById)(saveTimer)("1")
+    const decrementedTimerPromise = core.decrementTimerUseCase(findTimerById)(saveTimer)("1", date)
 
     it('should return a function after receving findTimerById', () => {
       core.decrementTimerUseCase(findTimerById).should.be.a('function')
@@ -595,9 +610,9 @@ describe('decrement timer use case', () => {
       return decrementedTimerPromise.should.eventually.have.property("id").equal("1")
     })
 
-    it('should have remainingDuration equal to duration minus intervalDuration', () => {
+    it('should have remainingDuration equal to remainingDuration minus (Date.now() - timer.startedAt)', () => {
       const timer = findTimerById()
-      return decrementedTimerPromise.should.eventually.have.property('remainingDuration').equal(timer.duration - timer.intervalDuration)
+      return decrementedTimerPromise.should.eventually.have.property('remainingDuration').equal(timer.remainingDuration - (date - timer.startedAt))
     })
     
   })


### PR DESCRIPTION
When a timer is created startedAt will be null. When starting a timer send a dateMs argument which is the result of Date.now(). When calling decrementTimer, also send DateMs. Stopping timer sets startedAt to null.